### PR TITLE
Make LocationService module utilize the official google maps node mod…

### DIFF
--- a/config/env_development.json
+++ b/config/env_development.json
@@ -1,4 +1,6 @@
 {
   "name": "development",
-  "description": "Add here any environment specific stuff you like."
+  "google_client_id": "609265890429-0evcp2uqktl726lf6ijfu56fpkh8c7cv.apps.googleusercontent.com",
+  "google_api_key": "AIzaSyDkiyjtUnxlzQUyxnu0WqUtkhyV8Q2KyA0",
+  "google_client_secret": "m-hzuH_h2O81XJkd2xNYY6QU"
 }

--- a/package.json
+++ b/package.json
@@ -59,9 +59,13 @@
     "spectron": "^3.3.0"
   },
   "dependencies": {
+    "@google/maps": "^0.3.0",
     "crypto-js": "^3.1.8",
     "googleapis": "^14.1.0",
+    "jquery": "^3.1.1",
     "moment": "^2.15.2",
+    "node-rest-client": "^2.0.1",
+    "typeahead": "^0.2.2",
     "yargs": "^6.3.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -18,8 +18,6 @@ import jetpack from 'fs-jetpack'; // module loaded from npm
 var app = remote.app;
 var appDir = jetpack.cwd(app.getAppPath());
 
-console.log('The author of this app is:', appDir.read('package.json', 'json').author);
-
 ipcRenderer.on('ready', (event, arg) => {
   var manager = new UIManager();
   manager.setVersion(appDir.read('package.json', 'json').version);

--- a/src/arbitrator/ArbitratorConfig.js
+++ b/src/arbitrator/ArbitratorConfig.js
@@ -1,6 +1,6 @@
 import { remote } from 'electron';
 import jetpack from 'fs-jetpack';
-import { secret } from './secret';
+import env from '../env';
 
 export var ArbitratorConfig = {
   /**
@@ -10,6 +10,7 @@ export var ArbitratorConfig = {
 
   // NOTE: These values should all be injected, based on the appropriate
   //       environment, during the build.
-  'google_client_id': secret.googleClientId,
-  'google_client_secret': secret.googleClientSecret
+  'google_client_id': env.google_client_id,
+  'google_client_secret': env.google_client_secret,
+  'google_api_key': env.google_api_key,
 };

--- a/src/arbitrator/UIManager.js
+++ b/src/arbitrator/UIManager.js
@@ -8,6 +8,7 @@ import { PreferenceSingleton, TimeType } from './PreferenceStore'
 import { Arbitrator } from './Arbitrator'
 import { Strings } from './Strings'
 import util from 'util'
+import { LocationService } from './LocationService'
 
 export var UIManager = function() {
 }
@@ -16,6 +17,7 @@ UIManager.prototype = {
   mGoogleClient: null,
   mBackStack: new Array(),
   mVersion: '0.0.0',
+  mLocationService: new LocationService(),
 
   /**
    * Perform functionality when the user clicks the 'Submit' button to indicate
@@ -209,7 +211,8 @@ UIManager.prototype = {
       }
 
       dataElement.find('label').attr('for', addressTextInputId).text(aPlace.getName());
-      dataElement.find('.locationTextInput').attr('id', addressTextInputId)
+      dataElement.find('.locationTextInput')
+                 .attr('id', addressTextInputId)
                  .attr('placeholder', addressPlaceholderText);
       dataElement.find('.locationTextInput.small').attr('id', subLocationTextInputId)
                  .attr('placeholder', subLocationPlaceholderText);
@@ -222,12 +225,21 @@ UIManager.prototype = {
       $('#locationInputs').append(dataElement);
       var addressElement = document.getElementById('locationAddressPref-' + aPlace.getShortName())
 
+      var Typeahead = require('typeahead');
+
       // Since this method is run every time preferences are refreshed, and in
       // order to generalize the loadContent() method a bit we refresh all
       // preferences on every content load, this should only be called if there
       // actually _is_ a location preference input element in the DOM.
       if (addressElement) {
-        // locService.enableAutoCompleteForElement(addressElement);
+        // Enable typeahead input on the address input element.
+        var locService = new LocationService();
+        Typeahead(addressElement, {
+          source: function (query, result) {
+            locService.getPredictionsForQuery(query, result);
+          }
+        });
+
         that._setLocationPreferenceOnClickHandlers();
       }
     });

--- a/src/stylesheets/arbitrator.scss
+++ b/src/stylesheets/arbitrator.scss
@@ -5,6 +5,7 @@
 @import 'snackbar';
 @import 'arbitrator-icons';
 @import 'font-awesome';
+@import 'typeahead';
 
 button, select {
   font-size: 14pt;

--- a/src/stylesheets/typeahead.scss
+++ b/src/stylesheets/typeahead.scss
@@ -1,0 +1,40 @@
+.typeahead {
+    margin-top: 2px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    float: left;
+    min-width: 160px;
+    padding: 5px 0;
+    margin: 2px 0 0;
+    list-style: none;
+    background-color: white;
+    border: 1px solid #CCC;
+}
+
+.typeahead li {
+    line-height: 20px;
+}
+
+.typeahead a {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 20px;
+    color: #333;
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+.typeahead .active > a {
+    color: white;
+    text-decoration: none;
+    background-color: #0081C2;
+    outline: 0;
+}
+
+.typeahead.hidden {
+    display: none;
+}


### PR DESCRIPTION
Refactor LocationService to utilize the official google maps node module.

## Issue References:
- Fixes #75.

## Development/Code Review Checklist
- [x] Documentation updated
- [x] Tests written for new features
- [x] Tests complete successfully
- [x] Formatting conforms to code style guidelines

…ule.

This re-enables the address prediction on the location settings view by
refactoring LocationService to utilize the official google maps node
module. Unfortunately, the previous module that was being used in the web
application doesn't work within an electron app. Further complicating this
is the fact that the @google/maps module doesn't give any method of
actually populating the dropdown list (this is only available in the web
app javascript library). Even worse, the <datalist> element doesn't work
within electron right now.

To solve all of these problems, the typeahead module was used to display
the list, and the individual predictions of Google Places comes from the
@google/maps module.

Fixes #75.