### PR TITLE
Fix incorrectly capitalized filename causing string resolution problems.

### DIFF
--- a/src/arbitrator/Strings.js
+++ b/src/arbitrator/Strings.js
@@ -1,3 +1,3 @@
 import jetpack from 'fs-jetpack'; // module loaded from npm
 
-export var Strings = jetpack.cwd(__dirname).read('Strings.json', 'json');
+export var Strings = jetpack.cwd(__dirname).read('strings.json', 'json');


### PR DESCRIPTION
Fixed a situation where strings file could not be resolved due to incorrect capitalization.

## Issue References:
- Fixes #79.

## Development/Code Review Checklist
- ~[ ] Documentation updated~
- ~[ ] Tests written for new features~
- [x] Tests complete successfully
- [x] Formatting conforms to code style guidelines

'strings.json' was incorrectly spelled as 'Strings.json' in the Strings.js
file. This is fine on non-case-sensitive file systems, such as those in Mac
OS/X and Windows, but is not conducive to correct file path resolution on
linux or other case-sensitive file systems.

Fixes #79.