### PR TITLE
Re-enable on click handlers on main view once main view is restored.

### DIFF
--- a/src/arbitrator/UIManager.js
+++ b/src/arbitrator/UIManager.js
@@ -536,34 +536,35 @@ UIManager.prototype = {
    *        load operation has completed.
    */
   loadContent: function(aContentFileName, aTitle, aOnComplete) {
-    var that = this;
+    var self = this;
 
     // Set the text of the nav drawer header
-    that.closeNavDrawer();
+    self.closeNavDrawer();
 
     $('main#content').load('partials/' + aContentFileName + '.partial.html', null,
                            function() {
-                             that._addToBackStack({
+                             self._addToBackStack({
                                'id': aContentFileName,
                                'name': aTitle
                              });
 
-                             if (!that._isBackStackEmpty()) {
-                               that._showBackArrow();
+                             if (!self._isBackStackEmpty()) {
+                               self._showBackArrow();
                              } else {
-                               that._showHamburgerIcon();
+                               self._showHamburgerIcon();
                              }
 
                              // Add the title to the app bar.
                              $('#pageTitle').text(aTitle);
 
                              // Add the version number to the app bar
-                             $('#versionNumber').text('v' + that.getVersion());
+                             $('#versionNumber').text('v' + self.getVersion());
 
                              if (aContentFileName == 'main') {
-                               that.refreshGoogleClient(function(aGoogleClient) {
-                                 that.populateCalendarList(aGoogleClient);
-                                 that.populateUserId(aGoogleClient);
+                               self.refreshGoogleClient(function(aGoogleClient) {
+                                 self.populateCalendarList(aGoogleClient);
+                                 self.populateUserId(aGoogleClient);
+                                 self._setArbitrateOnClickHandler();
                                });
                              }
 


### PR DESCRIPTION
Re-enable on click handler for submit button once user navigates back to main view (i.e. when `loadContent()` is called for `main` once more).

## Issue References:
- Fixes #93.

## Development/Code Review Checklist
- [x] Tests complete successfully
- [x] Formatting conforms to code style guidelines

We somehow lost the ability to submit games to a google calendar after the
user navigated away from the main page and then navigated back. The
onClick() handler for the submit button wasn't being set up properly. This
commit restores that functionality.

Fixes #93.