### PR TITLE
Modify game hash method to be two-way and based only on id and group.

### DIFF
--- a/src/arbitrator/ArbitratorGoogleClient.js
+++ b/src/arbitrator/ArbitratorGoogleClient.js
@@ -196,7 +196,7 @@ ArbitratorGoogleClient.prototype = {
           auth: oAuthClient
         });
 
-        var searchString = "{ArbitratorHash: " + aGame.getHash() + "}";
+        var searchString = "{ArbitratorHash: " + aGame.getGameInfoCipher() + "}";
         var req = cal.events.list({
           'calendarId' : aCalendarId
         }, {}, function (err, result) {

--- a/src/test/Arbitrator.spec.js
+++ b/src/test/Arbitrator.spec.js
@@ -118,7 +118,8 @@ describe("Arbitrator Translation Functionality", function () {
     expect(game.getSite().getName()).to.equal(gameJson.location);
     expect(game.getSummaryString()).to.equal(gameJson.summary);
 
-    var notes = "Game starts at " + String(game.getTime12Hr()) + "\n\n" + "{ArbitratorHash: " + String(game.getHash()) + "}"
+    var notes = "Game starts at " + String(game.getTime12Hr()) + "\n\n"
+      + "{ArbitratorHash: " + String(game.getGameInfoCipher()) + "}"
     expect(notes).to.equal(gameJson.description);
   });
 
@@ -197,5 +198,39 @@ describe("Arbitrator Translation Functionality", function () {
     expect(prefStore.hasAliasedGroups()).to.be.truthy;
 
     prefStore.removeGroupAlias('D6');
+  });
+
+  it ("should correctly compute an identification string and hash for valid games", function(done) {
+    var arbitrator = new Arbitrator(basicSchedule);
+
+    expect(arbitrator).to.not.be.null;
+    expect(arbitrator.getNumGames()).to.equal(2);
+    expect(arbitrator.getGameById(1827)).to.be.null;
+
+    var firstGame = arbitrator.getGameById(1111);
+    expect(firstGame).to.not.be.null;
+    expect(firstGame.getIdentificationString()).to.eq("106016-##-1111");
+
+    firstGame.getGameInfoCipher().then((cipher) => {
+      expect(cipher).to.eq('8af3229d1d0962c5b91ca85ceded9812');
+      done();
+    })
+    .catch((error) => {
+      done(error);
+    });
+  });
+
+  it ("should be able to resolve a game cipher back to a game id and group", function(done) {
+    Game.getGameInfoFromCipher('8af3229d1d0962c5b91ca85ceded9812')
+      .then((gameInfo) => {
+        var groupId = gameInfo.groupId;
+        var gameId = gameInfo.gameId;
+        expect(groupId).to.eq('106016');
+        expect(gameId).to.eq('1111');
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
   });
 });


### PR DESCRIPTION
This makes every Game object's getHash() method actually be a cipher which
will return a combination of game id and group id. In doing this, it allows
us to decipher the hash back to game id and group id, which sets us up to
more easily fix #67.

## Issue References:
- Fixes #84.
- Refs #67.

## Development/Code Review Checklist
- [x] Documentation updated
- [x] Tests written for new features
- [x] Tests complete successfully
- [x] Formatting conforms to code style guidelines
