### PR TITLE
Add a preference for controlling the last calendar the user entered.

### DIFF
--- a/src/arbitrator/Arbitrator.js
+++ b/src/arbitrator/Arbitrator.js
@@ -1,6 +1,6 @@
 import { Game } from './Game.js';
 import { UIManager } from './UIManager';
-import { PreferenceSingleton, TimeType } from './PreferenceStore';
+import { PreferenceSingleton, TimePreferenceKeys } from './PreferenceStore';
 import { ArbitratorGoogleClient } from './ArbitratorGoogleClient';
 import { Strings } from './Strings';
 
@@ -198,7 +198,7 @@ Arbitrator.prototype = {
    */
   findConsecutiveGames: function() {
     var prefStore = PreferenceSingleton.instance;
-    var gameLengthMins = prefStore.getTimePreference(TimeType.LENGTH_OF_GAME, 60);
+    var gameLengthMins = prefStore.getTimePreference(TimePreferenceKeys.LENGTH_OF_GAME, 60);
     var prevGame;
     for (var index in this.mGames) {
       var curGame = this.mGames[index];

--- a/src/arbitrator/ArbitratorGoogleClient.js
+++ b/src/arbitrator/ArbitratorGoogleClient.js
@@ -1,7 +1,7 @@
 import { ArbitratorConfig } from './ArbitratorConfig'
 import * as google from 'googleapis'
 import createWindow from '../helpers/window';
-import { PreferenceSingleton, TimeType } from './PreferenceStore';
+import { PreferenceSingleton, TimePreferenceKeys } from './PreferenceStore';
 import { Game } from './Game';
 
 // Specify default options to be used with all requests.

--- a/src/arbitrator/Game.js
+++ b/src/arbitrator/Game.js
@@ -1,6 +1,6 @@
 import  crypto from 'crypto';
 import { Place } from './Place'
-import { PreferenceSingleton, TimeType } from './PreferenceStore'
+import { PreferenceSingleton, TimePreferenceKeys } from './PreferenceStore'
 import * as moment from 'moment';
 import { Strings } from './Strings'
 
@@ -137,7 +137,7 @@ Game.prototype = {
   getISOStartDate: function() {
     var prefStore = PreferenceSingleton.instance;
     var startDate = this.getTimestamp();
-    var priorToStart = prefStore.getTimePreference(TimeType.PRIOR_TO_START, 30);
+    var priorToStart = prefStore.getTimePreference(TimePreferenceKeys.PRIOR_TO_START, 30);
     if (this.isConsecutiveGame()) {
       priorToStart = 0;
     }
@@ -150,7 +150,7 @@ Game.prototype = {
     var endDate = this.getTimestamp();
 
     // Default to 1 hour if no time preference is specified.
-    var gameLengthMins = prefStore.getTimePreference(TimeType.LENGTH_OF_GAME, 60);
+    var gameLengthMins = prefStore.getTimePreference(TimePreferenceKeys.LENGTH_OF_GAME, 60);
     return endDate.add(gameLengthMins, 'minutes').toISOString();
   },
 
@@ -189,7 +189,7 @@ Game.prototype = {
    */
   isWithinConsecutiveTimeRangeOf: function(aGame) {
     var prefStore = PreferenceSingleton.instance;
-    var consecutiveGameThreshold = prefStore.getTimePreference(TimeType.CONSECUTIVE_GAME_THRESHOLD, 2);
+    var consecutiveGameThreshold = prefStore.getTimePreference(TimePreferenceKeys.CONSECUTIVE_GAME_THRESHOLD, 2);
     var aOtherTimestamp = aGame.getTimestamp();
     var timeStamp = this.getTimestamp();
     return aOtherTimestamp.date() == timeStamp.date()

--- a/src/arbitrator/UIManager.js
+++ b/src/arbitrator/UIManager.js
@@ -4,7 +4,7 @@ import { Place } from './Place'
 import { ArbitratorGoogleClient } from './ArbitratorGoogleClient'
 import { ArbitratorConfig } from './ArbitratorConfig'
 import { StringUtils } from './StringUtils'
-import { PreferenceSingleton, TimeType } from './PreferenceStore'
+import { PreferenceSingleton, TimePreferenceKeys } from './PreferenceStore'
 import { Arbitrator } from './Arbitrator'
 import { Strings } from './Strings'
 import util from 'util'
@@ -499,6 +499,9 @@ UIManager.prototype = {
    *                                    api calls should be run with.
    */
   populateCalendarList: function(aGoogleClient) {
+    var prefStore = PreferenceSingleton.instance;
+    var lastCalendarId = prefStore.getLastCalendarId();
+
     var calendarSelector = $('#calendarList');
     var noCalendarSelectedOption = $('<option id="noCalendarSelectedOption">' + Strings.select_calendar + '</option>');
     calendarSelector.append(noCalendarSelectedOption);
@@ -513,7 +516,26 @@ UIManager.prototype = {
             listItem.text(calendarItem.summary);
             selectEle.append(listItem);
         }
+
+        // Select last calendar
+        if (lastCalendarId) {
+          var calChildren = calendarSelector.children();
+          calChildren.each(function(childNumber) {
+            var currentChild = $(calChildren[childNumber]);
+            if (currentChild.attr('id') == lastCalendarId) {
+              currentChild.prop('selected', 'selected');
+            }
+          });
+          // calendarSelector.find('option#' + lastCalendarId).prop('selected', 'selected');
+        }
+
         selectEle.css('display', 'block');
+      });
+
+      // Setup on change event
+      calendarSelector.off();
+      calendarSelector.change(function(event) {
+        prefStore.setLastCalendarId(event.target.selectedOptions[0].id);
       });
   },
 

--- a/src/test/Arbitrator.spec.js
+++ b/src/test/Arbitrator.spec.js
@@ -4,7 +4,7 @@ import { env } from '../env';
 import { Arbitrator } from '../arbitrator/Arbitrator';
 import { DONTCARE, checkGame } from './CheckGame';
 import * as moment from 'moment';
-import { PreferenceSingleton, TimeType } from '../arbitrator/PreferenceStore'
+import { PreferenceSingleton, TimePreferenceKeys } from '../arbitrator/PreferenceStore'
 import jetpack from 'fs-jetpack';
 
 var singleGame = jetpack.read('src/test/fixtures/singleGame.txt');
@@ -148,22 +148,22 @@ describe("Arbitrator Translation Functionality", function () {
   it ("recognizes time preferences set prior to parsing strings", function() {
     var prefStore = PreferenceSingleton.instance;
 
-    prefStore.addTimePreference(TimeType.PRIOR_TO_START, 61);
-    prefStore.addTimePreference(TimeType.LENGTH_OF_GAME, 90);
+    prefStore.addTimePreference(TimePreferenceKeys.PRIOR_TO_START, 61);
+    prefStore.addTimePreference(TimePreferenceKeys.LENGTH_OF_GAME, 90);
     prefStore.addGroupAlias('106016', 'D6');
 
     var arbitrator = new Arbitrator(basicSchedule);
 
     expect(arbitrator.getNumGames()).to.equal(2);
-    expect(prefStore.getTimePreference(TimeType.PRIOR_TO_START)).to.equal(61);
+    expect(prefStore.getTimePreference(TimePreferenceKeys.PRIOR_TO_START)).to.equal(61);
 
     var game = arbitrator.getGameById(1111);
     expect(game.getISOStartDate()).to.equal(moment("11/9/2013 12:30 PM").subtract(61, 'minutes').toISOString());
     expect(game.getISOEndDate()).to.equal(moment("11/9/2013 12:30 PM").add(90, 'minutes').toISOString());
     assert(game.getEventJSON().description.indexOf("Game starts at 12:30pm") > -1, 'the game should start at 12:30pm and this should be in the calendar event description');
 
-    prefStore.removeTimePreference(TimeType.PRIOR_TO_START);
-    prefStore.removeTimePreference(TimeType.LENGTH_OF_GAME);
+    prefStore.removeTimePreference(TimePreferenceKeys.PRIOR_TO_START);
+    prefStore.removeTimePreference(TimePreferenceKeys.LENGTH_OF_GAME);
 
     expect(game.getISOEndDate()).to.equal("2013-11-09T19:30:00.000Z");
     expect(game.getISOStartDate()).to.equal("2013-11-09T18:00:00.000Z");
@@ -176,8 +176,8 @@ describe("Arbitrator Translation Functionality", function () {
 
     expect(game).to.be.ok;
 
-    prefStore.addTimePreference(TimeType.PRIOR_TO_START, 60);
-    prefStore.addTimePreference(TimeType.LENGTH_OF_GAME, 120);
+    prefStore.addTimePreference(TimePreferenceKeys.PRIOR_TO_START, 60);
+    prefStore.addTimePreference(TimePreferenceKeys.LENGTH_OF_GAME, 120);
 
     // Basic game checking
     checkGame(arbitrator, 5422, DONTCARE, DONTCARE, 11, 22, 2014, 20, 40);

--- a/src/test/PreferenceStore.spec.js
+++ b/src/test/PreferenceStore.spec.js
@@ -1,4 +1,4 @@
-import { PreferenceSingleton, TimeType } from '../arbitrator/PreferenceStore';
+import { PreferenceSingleton, TimePreferenceKeys } from '../arbitrator/PreferenceStore';
 import { expect } from 'chai';
 import { LeagueProfile, GameClassificationLevel } from '../arbitrator/LeagueProfile';
 import jetpack from 'fs-jetpack';
@@ -15,9 +15,9 @@ describe("Preference Storage and Retrieval", function () {
     var prefStore1 = PreferenceSingleton.instance;
     var prefStore2 = PreferenceSingleton.instance;
 
-    prefStore1.addTimePreference(TimeType.PRIOR_TO_START, 61);
+    prefStore1.addTimePreference(TimePreferenceKeys.PRIOR_TO_START, 61);
 
-    expect(prefStore2.getTimePreference(TimeType.PRIOR_TO_START)).to.equal(61);
+    expect(prefStore2.getTimePreference(TimePreferenceKeys.PRIOR_TO_START)).to.equal(61);
   });
 
   it ("is able to add a new game age profile and subsequently retrieve it", function() {


### PR DESCRIPTION
This commit actually does a bit more than the above. It also restructures
all user-related preferences into its own object on the PreferenceStore,
named (aptly) "user". Finally, it organizes the preference store keys a
little better and changes the names of the objects used to access these
keys, for clarity.

## Issue References:
- Fixes #18.

## Development/Code Review Checklist
- [x] Documentation updated
- [x] Tests complete successfully
- [x] Formatting conforms to code style guidelines
